### PR TITLE
Add PR-preview for plane detection

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,7 @@
+{
+    "src_file": "plane-detection.bs",
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
+}


### PR DESCRIPTION
Note that PR preview does not seem to support working
with multiple bikeshed files at the same time, so for the time
being, it's configured for plane-detection only. We can
reconfigure it to meshing once we want to revisit it, hopefully
by that time plane-detection will be fairly stable.