### PR TITLE
Remove extra line about semantic labels table

### DIFF
--- a/plane-detection.bs
+++ b/plane-detection.bs
@@ -202,7 +202,7 @@ The {{XRPlane/polygon}} is an array of vertices that describe the shape of the p
 
 The {{XRPlane/semanticLabel}} attribute is a string that describes the [=semantic label=] of the polygon. This array is empty if there is no semantic information. The {{XRSystem}} SHOULD populate this  with the [=semantic label=] it has knowledge of.
 
-A <dfn>semantic label</dfn> is an ASCII lowercase DOMString that describes the name in the real world of the {{XRPlane}} as known by the {{XRSystem}}. The following table describes the known [=semantic label|semantic labels=]:
+A <dfn>semantic label</dfn> is an ASCII lowercase DOMString that describes the name in the real world of the {{XRPlane}} as known by the {{XRSystem}}.
 The list of semantic labels is defined in the <a href="https://github.com/immersive-web/semantic-labels">semantic label registry</a>.
 
 </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msub2/real-world-geometry/pull/42.html" title="Last updated on Nov 7, 2023, 7:57 PM UTC (9591650)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/real-world-geometry/42/cf67ca4...msub2:9591650.html" title="Last updated on Nov 7, 2023, 7:57 PM UTC (9591650)">Diff</a>